### PR TITLE
Replace grunt-recess with grunt-contrib-less

### DIFF
--- a/interface/Gruntfile.js
+++ b/interface/Gruntfile.js
@@ -10,10 +10,10 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks("grunt-contrib-watch");
   grunt.loadNpmTasks("grunt-contrib-uglify");
   grunt.loadNpmTasks("grunt-contrib-coffee");
+  grunt.loadNpmTasks('grunt-contrib-less');
   grunt.loadNpmTasks("grunt-conventional-changelog");
   grunt.loadNpmTasks("grunt-bump");
   grunt.loadNpmTasks("grunt-coffeelint");
-  grunt.loadNpmTasks("grunt-recess");
   grunt.loadNpmTasks("grunt-karma");
   grunt.loadNpmTasks("grunt-ngmin");
   grunt.loadNpmTasks("grunt-html2js");
@@ -151,8 +151,11 @@ module.exports = function(grunt) {
        * together.
        */
       build_css: {
-        src: ["<%= vendor_files.css %>", "<%= recess.build.dest %>"],
-        dest: "<%= recess.build.dest %>"
+        src: [
+          "<%= vendor_files.css %>",
+          "<%= build_dir %>/assets/<%= pkg.name %>-<%= pkg.version %>.css"
+        ],
+        dest: "<%= build_dir %>/assets/<%= pkg.name %>-<%= pkg.version %>.css"
       },
       /**
        * The `compile_js` target is the concatenation of our application source
@@ -226,31 +229,23 @@ module.exports = function(grunt) {
     },
 
     /**
-     * `recess` handles our LESS compilation and uglification automatically.
+     * `grunt-contrib-less` handles our LESS compilation and uglification automatically.
      * Only our `main.less` file is included in compilation; all other files
      * must be imported from this file.
      */
-    recess: {
+    less: {
       build: {
-        src: ["<%= app_files.less %>"],
-        dest: "<%= build_dir %>/assets/<%= pkg.name %>-<%= pkg.version %>.css",
-        options: {
-          compile: true,
-          compress: false,
-          noUnderscores: false,
-          noIDs: false,
-          zeroUnits: false
+        files: {
+          "<%= build_dir %>/assets/<%= pkg.name %>-<%= pkg.version %>.css": "<%= app_files.less %>"
         }
       },
       compile: {
-        src: ["<%= recess.build.dest %>"],
-        dest: "<%= recess.build.dest %>",
+        files: {
+          "<%= build_dir %>/assets/<%= pkg.name %>-<%= pkg.version %>.css": "<%= app_files.less %>"
+        },
         options: {
-          compile: true,
-          compress: true,
-          noUnderscores: false,
-          noIDs: false,
-          zeroUnits: false
+          cleancss: true,
+          compress: true
         }
       }
     },
@@ -372,7 +367,7 @@ module.exports = function(grunt) {
           "<%= html2js.common.dest %>",
           "<%= html2js.app.dest %>",
           "<%= vendor_files.css %>",
-          "<%= recess.build.dest %>"
+	  "<%= build_dir %>/assets/<%= pkg.name %>-<%= pkg.version %>.css"
         ]
       },
 
@@ -386,7 +381,7 @@ module.exports = function(grunt) {
         src: [
           "<%= concat.compile_js.dest %>",
           "<%= vendor_files.css %>",
-          "<%= recess.compile.dest %>"
+          "<%= build_dir %>/assets/<%= pkg.name %>-<%= pkg.version %>.css"
         ]
       }
     },
@@ -493,7 +488,7 @@ module.exports = function(grunt) {
        */
       less: {
         files: ["src/**/*.less"],
-        tasks: ["recess:build", "concat:build_css"]
+        tasks: ["less:build"]
       },
 
       /**
@@ -548,7 +543,7 @@ module.exports = function(grunt) {
     "jshint",
     "coffeelint",
     "coffee",
-    "recess:build",
+    "less:build",
     "concat:build_css",
     "copy:build_app_assets",
     "copy:build_vendor_assets",
@@ -563,7 +558,7 @@ module.exports = function(grunt) {
    * minifying your code.
    */
   grunt.registerTask("compile", [
-    "recess:compile",
+    "less:compile",
     "copy:compile_assets",
     "ngmin",
     "concat:compile_js",

--- a/interface/bower.json
+++ b/interface/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "tribe-frontend",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "devDependencies": {},
   "dependencies": {
     "angular": "~1.2.0",

--- a/interface/package-lock.json
+++ b/interface/package-lock.json
@@ -475,9 +475,9 @@
       "dev": true
     },
     "blob": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
-      "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE=",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
+      "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==",
       "dev": true
     },
     "bluebird": {
@@ -753,9 +753,9 @@
       }
     },
     "circular-json": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.5.7.tgz",
-      "integrity": "sha512-/pXoV1JA847qRKPrHbBK6YIBGFF8GOP4wzSgUOA7q0ew0vAv0iJswP+2/nZQ9uzA3Azi7eTrg9L2yzXc/7ZMIA==",
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.5.9.tgz",
+      "integrity": "sha512-4ivwqHpIFJZBuhN3g/pEcdbnGUywkBblloGbkglyloVjjR3uT6tieI89MVOfbP2tHX5sgb01FuLgAOzebNlJNQ==",
       "dev": true
     },
     "class-utils": {
@@ -1924,9 +1924,9 @@
       "dev": true
     },
     "engine.io": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.0.tgz",
-      "integrity": "sha512-mRbgmAtQ4GAlKwuPnnAvXXwdPhEx+jkc0OBCLrXuD/CRvwNK3AxRSnqK4FSqmAMRRHryVJP8TopOvmEaA64fKw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.1.tgz",
+      "integrity": "sha512-+VlKzHzMhaU+GsCIg4AoXF1UdDFjHHwMmMKqMJNDNLlUlejz58FCy4LBqB2YVJskHGYl06BatYWKP2TVdVXE5w==",
       "dev": true,
       "requires": {
         "accepts": "~1.3.4",
@@ -1979,15 +1979,15 @@
       }
     },
     "engine.io-parser": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.2.tgz",
-      "integrity": "sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.3.tgz",
+      "integrity": "sha512-6HXPre2O4Houl7c4g7Ic/XzPnHBvaEmN90vtRO9uLmwtRqQmTOw0QMevL1TOfL2Cpu1VzsaTmMotQgMdkzGkVA==",
       "dev": true,
       "requires": {
         "after": "0.8.2",
         "arraybuffer.slice": "~0.0.7",
         "base64-arraybuffer": "0.1.5",
-        "blob": "0.0.4",
+        "blob": "0.0.5",
         "has-binary2": "~1.0.2"
       }
     },
@@ -2104,15 +2104,6 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
       "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==",
       "dev": true
-    },
-    "exec-sh": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
-      "integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
-      "dev": true,
-      "requires": {
-        "merge": "^1.2.0"
-      }
     },
     "exit": {
       "version": "0.1.2",
@@ -3899,58 +3890,6 @@
         "ngmin": "~0.4.0"
       }
     },
-    "grunt-recess": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/grunt-recess/-/grunt-recess-1.0.1.tgz",
-      "integrity": "sha1-1Xf5R7+k4oIzSVdK4bV1ytuAWWM=",
-      "dev": true,
-      "requires": {
-        "async": "^0.9.0",
-        "chalk": "^1.0.0",
-        "lodash": "^3.3.0",
-        "maxmin": "^1.0.0",
-        "recess": "^1.1.6"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "async": {
-          "version": "0.9.2",
-          "resolved": "http://registry.npmjs.org/async/-/async-0.9.2.tgz",
-          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
-    },
     "gzip-size": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-1.0.0.tgz",
@@ -4755,9 +4694,9 @@
       }
     },
     "karma": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-3.0.0.tgz",
-      "integrity": "sha512-ZTjyuDXVXhXsvJ1E4CnZzbCjSxD6sEdzEsFYogLuZM0yqvg/mgz+O+R1jb0J7uAQeuzdY8kJgx6hSNXLwFuHIQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-3.1.1.tgz",
+      "integrity": "sha512-NetT3wPCQMNB36uiL9LLyhrOt8SQwrEKt0xD3+KpTCfm0VxVyUJdPL5oTq2Ic5ouemgL/Iz4wqXEbF3zea9kQQ==",
       "dev": true,
       "requires": {
         "bluebird": "^3.3.0",
@@ -5485,7 +5424,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
@@ -5506,12 +5445,6 @@
         "redent": "^1.0.0",
         "trim-newlines": "^1.0.0"
       }
-    },
-    "merge": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
-      "dev": true
     },
     "micromatch": {
       "version": "2.3.11",
@@ -6811,30 +6744,6 @@
         }
       }
     },
-    "recess": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/recess/-/recess-1.1.9.tgz",
-      "integrity": "sha1-gxxVH0Xfh9SExhI//ekQML7xWBo=",
-      "dev": true,
-      "requires": {
-        "colors": ">= 0.3.0",
-        "less": "~1.3.0",
-        "nopt": ">= 1.0.10",
-        "underscore": ">= 1.2.1",
-        "watch": ">= 0.5.1"
-      },
-      "dependencies": {
-        "less": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/less/-/less-1.3.3.tgz",
-          "integrity": "sha1-fujzAKQQgPNUTIDHpwzfamEoDPk=",
-          "dev": true,
-          "requires": {
-            "ycssmin": ">=1.0.1"
-          }
-        }
-      }
-    },
     "redent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
@@ -7854,12 +7763,6 @@
       "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
       "dev": true
     },
-    "underscore": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
-      "dev": true
-    },
     "underscore.string": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.5.tgz",
@@ -8063,16 +7966,6 @@
       "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
       "dev": true
     },
-    "watch": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/watch/-/watch-1.0.2.tgz",
-      "integrity": "sha1-NApxe952Vyb6CqB9ch4BR6VR3ww=",
-      "dev": true,
-      "requires": {
-        "exec-sh": "^0.2.0",
-        "minimist": "^1.2.0"
-      }
-    },
     "websocket-driver": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
@@ -8215,13 +8108,6 @@
       "requires": {
         "fd-slicer": "~1.0.1"
       }
-    },
-    "ycssmin": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ycssmin/-/ycssmin-1.0.1.tgz",
-      "integrity": "sha1-fN3o23jPqwDSkBw7IwHjBPr03xY=",
-      "dev": true,
-      "optional": true
     },
     "yeast": {
       "version": "0.1.2",

--- a/interface/package.json
+++ b/interface/package.json
@@ -1,7 +1,7 @@
 {
   "author": "GreeneLab",
   "name": "tribe-frontend",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Tribe web server",
   "homepage": "https://tribe.greenelab.com",
   "license": "(MIT OR BSD-3-Clause)",
@@ -36,13 +36,12 @@
     "grunt-html2js": "^0.5.1",
     "grunt-karma": "^3.0.0",
     "grunt-ngmin": "^0.0.3",
-    "grunt-recess": "~1.0.1",
     "jasmine-core": "^2.4.1",
-    "karma": "^3.0.0",
-    "karma-jasmine": "^1.1.1",
+    "karma": "^3.1.1",
     "karma-chrome-launcher": "^2.0.0",
     "karma-coffee-preprocessor": "^1.0.1",
     "karma-firefox-launcher": "^1.0.0",
+    "karma-jasmine": "^1.1.1",
     "karma-phantomjs-launcher": "^1.0.1",
     "karma-safari-launcher": "^1.0.0"
   }

--- a/interface/tools.md
+++ b/interface/tools.md
@@ -88,7 +88,7 @@ First, we tell Grunt which tasks we might want to use:
 
 ```js
 // ...
-grunt.loadNpmTasks('grunt-recess');
+grunt.loadNpmTasks('grunt-less');
 grunt.loadNpmTasks('grunt-contrib-clean');
 grunt.loadNpmTasks('grunt-contrib-copy');
 grunt.loadNpmTasks('grunt-contrib-jshint');
@@ -134,7 +134,7 @@ $ grunt karma:continuous
 $ grunt concat
 $ grunt ngmin:dist
 $ grunt uglify
-$ grunt recess
+$ grunt less
 $ grunt index
 $ grunt copy
 ```
@@ -220,4 +220,3 @@ through the [main README](README.md) to dive another level deeper and apply what
 you've learned for great good. I promise it will all make sense it short order.
 
 Happy programming!
-


### PR DESCRIPTION
As discussed in issue #23, `grunt-recess` is deprecated. To make the situation worse, it causes a security alert: https://github.com/greenelab/tribe/network/alerts

This PR removes `grunt-recess`, and uses `grunt-contrib-less` to build CSS files in `Gruntfile.js`. The modification is based on:
https://github.com/ngbp/ngbp/blob/v0.3.2-release/Gruntfile.js

The new building process has been tested on my local desktop.