### PR TITLE
Update haystack backend to version 2

### DIFF
--- a/tribe/config/production.ini
+++ b/tribe/config/production.ini
@@ -51,7 +51,7 @@ STATIC_URL: /static/
 [404 mail]
 
 [haystack]
-ENGINE: haystack.backends.elasticsearch_backend.ElasticsearchSearchEngine
+ENGINE: haystack.backends.elasticsearch2_backend.Elasticsearch2SearchEngine
 URL: http://127.0.0.1:9200/
 INDEX_NAME: tribe
 LOAD_PER_QUERY: 20000


### PR DESCRIPTION
I forgot to update the haystack backend settings to version 2. 

(The new settings have been tested on a local server.)