### PR TITLE
Use Elasticsearch docker container in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,9 @@ jobs:
         environment:
           POSTGRES_USER: root
 
-      # Secondary docker container for database service
+      # Secondary docker container for Elasticsearch service
       - image: elasticsearch:2.4.6
+        command: [echo "index.max_result_window: 20000" >> /etc/elasticsearch/elasticsearch.yml]
 
     working_directory: ~/tribe
 
@@ -26,8 +27,8 @@ jobs:
           command: |
             apt update && apt upgrade -y
             apt install curl -y
-            curl -X PUT "localhost:9200/_settings" -H 'Content-Type: application/json' \
-            -d'{"index" : {"max_result_window" : 20000}}'
+            #curl -XPUT "localhost:9200/test_index"
+            #curl -XPUT "localhost:9200/_settings" -d '{"index.max_result_window" : 20000}'
       - run:
           name: Create Django configuration file
           working_directory: ~/tribe/tribe/config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
 
       # Secondary docker container for Elasticsearch service
       - image: elasticsearch:2.4.6
-        command: echo "index.max_result_window: 20000" >> /etc/elasticsearch/elasticsearch.yml
+        command: 'echo "index.max_result_window: 20000" >> /etc/elasticsearch/elasticsearch.yml'
 
     working_directory: ~/tribe
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
 
       # Secondary docker container for Elasticsearch service
       - image: elasticsearch:2.4.6
-        command: [echo "index.max_result_window: 20000" >> /etc/elasticsearch/elasticsearch.yml]
+        command: echo "index.max_result_window: 20000" >> /etc/elasticsearch/elasticsearch.yml
 
     working_directory: ~/tribe
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,8 @@ jobs:
           name: Configure Elasticsearch
           working_directory: /tmp
           command: |
+            apt update && apt upgrade -y
+            apt install curl -y
             curl -X PUT "localhost:9200/_settings" -H 'Content-Type: application/json' \
             -d'{"index" : {"max_result_window" : 20000}}'
       - run:
@@ -34,7 +36,6 @@ jobs:
       - run:
           name: Backend tests
           command: |
-            apt update && apt upgrade -y
             apt install postgresql-client python-pip -y
             createuser -h localhost --superuser tribe
             createdb -h localhost circleci_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,12 @@ jobs:
       - image: ubuntu:18.04
 
       # Secondary docker container for database service
-      - image: postgres:9.5.14
+      - image: postgres:9.6.11
         environment:
           POSTGRES_USER: root
+
+      # Secondary docker container for database service
+      - image: elasticsearch:2.4.6
 
     working_directory: ~/tribe
 
@@ -18,15 +21,11 @@ jobs:
       # "index.max_result_window" option (without which some unit tests will
       # fail), so we have to install Elasticsearch manually.
       - run:
-          name: Set up Elasticsearch
+          name: Configure Elasticsearch
           working_directory: /tmp
           command: |
-            apt update && apt upgrade -y
-            apt install git wget openjdk-8-jre-headless -y
-            wget https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.4.6/elasticsearch-2.4.6.deb
-            apt install ./elasticsearch-2.4.6.deb
-            echo "index.max_result_window: 20000" >> /etc/elasticsearch/elasticsearch.yml
-            /etc/init.d/elasticsearch restart
+            curl -X PUT "localhost:9200/_settings" -H 'Content-Type: application/json' \
+            -d'{"index" : {"max_result_window" : 20000}}'
       - run:
           name: Create Django configuration file
           working_directory: ~/tribe/tribe/config
@@ -35,6 +34,7 @@ jobs:
       - run:
           name: Backend tests
           command: |
+            apt update && apt upgrade -y
             apt install postgresql-client python-pip -y
             createuser -h localhost --superuser tribe
             createdb -h localhost circleci_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       # Secondary docker container for Elasticsearch service
       - image: elasticsearch:2.4.6
         #command: 'echo "index.max_result_window: 20000" >> /etc/elasticsearch/elasticsearch.yml'
-        command: [elasticsearch, --index.max_result_window, 20000]
+        command: [elasticsearch, '--index.max_result_window', '20000']
 
     working_directory: ~/tribe
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,24 +12,12 @@ jobs:
 
       # Secondary docker container for Elasticsearch service
       - image: elasticsearch:2.4.6
-        #command: 'echo "index.max_result_window: 20000" >> /etc/elasticsearch/elasticsearch.yml'
         command: [elasticsearch, '--index.max_result_window', '20000']
 
     working_directory: ~/tribe
 
     steps:
       - checkout
-      # The generic docker image "elasticsearch" doesn't allow us to customize
-      # "index.max_result_window" option (without which some unit tests will
-      # fail), so we have to install Elasticsearch manually.
-      - run:
-          name: Configure Elasticsearch
-          working_directory: /tmp
-          command: |
-            apt update && apt upgrade -y
-            apt install curl -y
-            #curl -XPUT "localhost:9200/test_index"
-            #curl -XPUT "localhost:9200/_settings" -d '{"index.max_result_window" : 20000}'
       - run:
           name: Create Django configuration file
           working_directory: ~/tribe/tribe/config
@@ -38,7 +26,8 @@ jobs:
       - run:
           name: Backend tests
           command: |
-            apt install postgresql-client python-pip -y
+            apt update && apt upgrade -y
+            apt install postgresql-client python-pip git -y
             createuser -h localhost --superuser tribe
             createdb -h localhost circleci_test
             pip install -r requirements.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           name: Frontend tests
           working_directory: ~/tribe/interface
           command: |
-            apt install node.js npm -y
+            apt install node.js npm libfontconfig -y
             npm -g install grunt-cli karma-cli bower
             npm install
             bower install --allow-root

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,8 @@ jobs:
 
       # Secondary docker container for Elasticsearch service
       - image: elasticsearch:2.4.6
-        command: 'echo "index.max_result_window: 20000" >> /etc/elasticsearch/elasticsearch.yml'
+        #command: 'echo "index.max_result_window: 20000" >> /etc/elasticsearch/elasticsearch.yml'
+        command: [elasticsearch, --index.max_result_window, 20000]
 
     working_directory: ~/tribe
 

--- a/tribe/settings.py
+++ b/tribe/settings.py
@@ -25,29 +25,6 @@ path.append(PROJECT_ROOT)
 ########## END PATH CONFIGURATION
 
 
-########## CODESHIP CONFIG
-cs = os.environ.get('CODESHIP_SETTINGS')
-if cs == 'YES':
-    pg_user = os.environ.get('PG_USER')
-    pg_pass = os.environ.get('PG_PASSWORD')
-    cs_secret = SafeConfigParser()
-    cs_secret.read(normpath(join(config_dir, 'example_secrets.ini')))
-    import random
-    cs_secret.set('secrets', 'SECRET_KEY', str(random.randint(0, 1000000)))
-    cs_secret.set('database', 'DATABASE_PASSWORD', pg_pass)
-    cs_secret.set('include', 'FILE_NAME', 'test.ini')
-    cs_secret_fh = open(normpath(join(config_dir, 'secrets.ini')), 'w')
-    cs_secret.write(cs_secret_fh)
-    cs_secret_fh.close()
-    cs_config = SafeConfigParser()
-    cs_config.read(normpath(join(config_dir, 'test_template.ini')))
-    cs_config.set('database', 'DATABASE_USER', pg_user)
-    cs_config_fh = open(normpath(join(config_dir, 'test.ini')), 'w')
-    cs_config.write(cs_config_fh)
-    cs_config_fh.close()
-########## END CODESHIP CONFIG
-
-
 ########## INI CONFIGURATION
 config = get_config(config_dir, 'secrets.ini')
 ########## END INI CONFIGURATION


### PR DESCRIPTION
This PR removes the manual installation of `Elasticsearch` in CircleCI and uses a docker container with specific `index.max_result_window` option. 

`Codeship` section is also removed from `setting.py`.